### PR TITLE
db: fix change detection for symlinks

### DIFF
--- a/src/apk_fs.h
+++ b/src/apk_fs.h
@@ -42,7 +42,7 @@ struct apk_fsdir_ops {
 
 	int (*file_extract)(struct apk_ctx *, const struct apk_file_info *, struct apk_istream *, apk_progress_cb, void *, unsigned int, apk_blob_t);
 	int (*file_control)(struct apk_fsdir *, apk_blob_t, int);
-	int (*file_digest)(struct apk_fsdir *, apk_blob_t, uint8_t alg, struct apk_digest *);
+	int (*file_info)(struct apk_fsdir *, apk_blob_t, unsigned int, struct apk_file_info *);
 };
 
 #define APK_FSEXTRACTF_NO_CHOWN		0x0001
@@ -72,8 +72,8 @@ static inline int apk_fsdir_update_perms(struct apk_fsdir *fs, mode_t mode, uid_
 static inline int apk_fsdir_file_control(struct apk_fsdir *fs, apk_blob_t filename, int ctrl) {
 	return fs->ops->file_control(fs, filename, ctrl);
 }
-static inline int apk_fsdir_file_digest(struct apk_fsdir *fs, apk_blob_t filename, uint8_t alg, struct apk_digest *dgst) {
-	return fs->ops->file_digest(fs, filename, alg, dgst);
+static inline int apk_fsdir_file_info(struct apk_fsdir *fs, apk_blob_t filename, unsigned int flags, struct apk_file_info *fi) {
+	return fs->ops->file_info(fs, filename, flags, fi);
 }
 
 #endif

--- a/src/fs_uvol.c
+++ b/src/fs_uvol.c
@@ -150,7 +150,7 @@ static int uvol_file_control(struct apk_fsdir *d, apk_blob_t filename, int ctrl)
 	}
 }
 
-static int uvol_file_digest(struct apk_fsdir *d, apk_blob_t filename, uint8_t alg, struct apk_digest *dgst)
+static int uvol_file_info(struct apk_fsdir *d, apk_blob_t filename, unsigned int flags, struct apk_file_info *fi)
 {
 	return -APKE_UVOL_ERROR;
 }
@@ -163,5 +163,5 @@ const struct apk_fsdir_ops fsdir_ops_uvol = {
 	.dir_update_perms = uvol_dir_update_perms,
 	.file_extract = uvol_file_extract,
 	.file_control = uvol_file_control,
-	.file_digest = uvol_file_digest,
+	.file_info = uvol_file_info,
 };


### PR DESCRIPTION
apk_fileinfo_get() special cases symlink digest calculation. Convert apk_fsdir_ops.file_digest to .file_info to fix symlink change detection.

fixes #10853